### PR TITLE
server now specified in .env only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+TWINLAB_TRAINING_SERVER=https://cma567qwquixu7bbjcnhbjsxjm0yumvu.lambda-url.eu-west-2.on.aws/
 TWINLAB_SERVER=https://qisuqloa39.execute-api.eu-west-2.amazonaws.com/prod
 TWINLAB_GROUPNAME=
 TWINLAB_USERNAME=

--- a/notebooks/basic.ipynb
+++ b/notebooks/basic.ipynb
@@ -33,10 +33,7 @@
     "file_params = os.path.join(campaign_dir, \"params.json\")\n",
     "\n",
     "# Campaign id\n",
-    "campaign_id = \"basic\"\n",
-    "\n",
-    "# Server\n",
-    "server = \"cloud\""
+    "campaign_id = \"basic\""
    ]
   },
   {
@@ -46,7 +43,7 @@
    "outputs": [],
    "source": [
     "# Upload dataset to the cloud\n",
-    "tl.upload_dataset(file_train, server=server, verbose=True)"
+    "tl.upload_dataset(file_train, verbose=True)"
    ]
   },
   {
@@ -56,7 +53,7 @@
    "outputs": [],
    "source": [
     "# List datasets\n",
-    "_ = tl.list_datasets(server=server, verbose=True)"
+    "_ = tl.list_datasets(verbose=True)"
    ]
   },
   {
@@ -66,7 +63,7 @@
    "outputs": [],
    "source": [
     "# Start a new campaign and train an emulator\n",
-    "tl.train_campaign(file_params, campaign_id, server=server, verbose=True)"
+    "tl.train_campaign(file_params, campaign_id, verbose=True)"
    ]
   },
   {
@@ -76,7 +73,7 @@
    "outputs": [],
    "source": [
     "# List campaigns\n",
-    "_ = tl.list_campaigns(server=server, verbose=True)"
+    "_ = tl.list_campaigns(verbose=True)"
    ]
   },
   {
@@ -86,7 +83,7 @@
    "outputs": [],
    "source": [
     "# Look at the status of a campaign\n",
-    "_ = tl.query_campaign(campaign_id, server=server, verbose=True)"
+    "_ = tl.query_campaign(campaign_id, verbose=True)"
    ]
   },
   {
@@ -96,7 +93,7 @@
    "outputs": [],
    "source": [
     "# Predict using the trained emulator\n",
-    "df_mean, df_std = tl.predict_campaign(file_eval, campaign_id, server=server, verbose=True)"
+    "df_mean, df_std = tl.predict_campaign(file_eval, campaign_id, verbose=True)"
    ]
   },
   {
@@ -153,8 +150,8 @@
    "outputs": [],
    "source": [
     "# Delete campaign and dataset (if desired)\n",
-    "tl.delete_campaign(campaign_id, server=server, verbose=True)\n",
-    "tl.delete_dataset(file_train, server=server, verbose=True)"
+    "tl.delete_campaign(campaign_id, verbose=True)\n",
+    "tl.delete_dataset(file_train, verbose=True)"
    ]
   }
  ],

--- a/notebooks/ukaea.ipynb
+++ b/notebooks/ukaea.ipynb
@@ -60,10 +60,7 @@
     "file_eval = os.path.join(campaign_dir, \"test.csv\")\n",
     "\n",
     "# Campaign parameters\n",
-    "campaign = \"ukaea\"\n",
-    "\n",
-    "# Server\n",
-    "server = \"cloud\""
+    "campaign = \"ukaea\""
    ]
   },
   {
@@ -127,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tl.upload_dataset(file_train, server=server, verbose=True)"
+    "tl.upload_dataset(file_train, verbose=True)"
    ]
   },
   {
@@ -144,7 +141,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_ = tl.list_datasets(server=server, verbose=True)"
+    "_ = tl.list_datasets(verbose=True)"
    ]
   },
   {
@@ -161,7 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tl.query_dataset(params[\"filename\"], server=server, verbose=True)"
+    "tl.query_dataset(params[\"filename\"], verbose=True)"
    ]
   },
   {
@@ -178,7 +175,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tl.train_campaign(params, campaign, server=server, verbose=True)"
+    "tl.train_campaign(params, campaign, verbose=True)"
    ]
   },
   {
@@ -195,7 +192,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_ = tl.list_campaigns(server=server, verbose=True)"
+    "_ = tl.list_campaigns(verbose=True)"
    ]
   },
   {
@@ -212,7 +209,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_ = tl.query_campaign(campaign, server=server, verbose=True)"
+    "_ = tl.query_campaign(campaign, verbose=True)"
    ]
   },
   {
@@ -229,7 +226,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_mean, df_std = tl.predict_campaign(file_eval, campaign, server=server, verbose=False)"
+    "df_mean, df_std = tl.predict_campaign(file_eval, campaign, verbose=False)"
    ]
   },
   {
@@ -346,8 +343,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tl.delete_campaign(campaign, server=server, verbose=True)\n",
-    "tl.delete_dataset(dataset, server=server, verbose=True)"
+    "tl.delete_campaign(campaign, verbose=True)\n",
+    "tl.delete_dataset(dataset, verbose=True)"
    ]
   }
  ],

--- a/scripts/delete_campaign.py
+++ b/scripts/delete_campaign.py
@@ -3,5 +3,4 @@ import twinlab as tl
 
 print()  #  Initial white space
 campaign_name = "biscuits"
-server = tl.get_command_line_args().server
-tl.delete_campaign(campaign_name, server=server, verbose=True, debug=True)
+tl.delete_campaign(campaign_name, verbose=True, debug=True)

--- a/scripts/delete_dataset.py
+++ b/scripts/delete_dataset.py
@@ -3,5 +3,4 @@ import twinlab as tl
 
 print()  #  Initial white space
 dataset_name = "biscuits.csv"
-server = tl.get_command_line_args().server
-tl.delete_dataset(dataset_name, server=server, verbose=True, debug=True)
+tl.delete_dataset(dataset_name, verbose=True, debug=True)

--- a/scripts/list_campaigns.py
+++ b/scripts/list_campaigns.py
@@ -2,5 +2,4 @@
 import twinlab as tl
 
 print()  #  Initial white space
-server = tl.get_command_line_args().server
-_ = tl.list_campaigns(server=server, verbose=True, debug=True)
+_ = tl.list_campaigns(verbose=True, debug=True)

--- a/scripts/list_datasets.py
+++ b/scripts/list_datasets.py
@@ -2,5 +2,4 @@
 import twinlab as tl
 
 print()  #  Initial white space
-server = tl.get_command_line_args().server
-_ = tl.list_datasets(server=server, verbose=True, debug=True)
+_ = tl.list_datasets(verbose=True, debug=True)

--- a/scripts/predict_campaign.py
+++ b/scripts/predict_campaign.py
@@ -9,6 +9,5 @@ directory = os.path.join("campaigns", "biscuits")
 filename = "eval.csv"
 campaign_name = "biscuits"
 filepath = os.path.join(directory, filename)
-server = tl.get_command_line_args().server
 df_mean, df_std = tl.predict_campaign(
-    filepath, campaign_name, server=server, verbose=True, debug=True)
+    filepath, campaign_name, verbose=True, debug=True)

--- a/scripts/query_campaign.py
+++ b/scripts/query_campaign.py
@@ -3,5 +3,4 @@ import twinlab as tl
 
 print()  #  Initial white space
 campaign_name = "biscuits"
-server = tl.get_command_line_args().server
-tl.query_campaign(campaign_name, server=server, verbose=True, debug=True)
+tl.query_campaign(campaign_name, verbose=True, debug=True)

--- a/scripts/query_dataset.py
+++ b/scripts/query_dataset.py
@@ -3,5 +3,4 @@ import twinlab as tl
 
 print()  #  Initial white space
 dataset_name = "biscuits.csv"
-server = tl.get_command_line_args().server
-tl.query_dataset(dataset_name, server=server, verbose=True, debug=True)
+tl.query_dataset(dataset_name, verbose=True, debug=True)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -17,17 +17,16 @@ verbose = True
 debug = False
 
 print()  #  Initial white space
-server = tl.get_command_line_args().server
-tl.upload_dataset(training_filepath, server=server,
+tl.upload_dataset(training_filepath,
                   verbose=verbose, debug=debug)
-tl.query_dataset(dataset_name, server=server, verbose=verbose, debug=debug)
-tl.list_datasets(server=server, verbose=verbose, debug=debug)
-tl.train_campaign(params_filepath, campaign_name, server=server,
+tl.query_dataset(dataset_name, verbose=verbose, debug=debug)
+tl.list_datasets(verbose=verbose, debug=debug)
+tl.train_campaign(params_filepath, campaign_name,
                   verbose=verbose, debug=debug)
-tl.query_campaign(campaign_name, server=server, verbose=verbose, debug=debug)
-tl.list_campaigns(server=server, verbose=verbose, debug=debug)
+tl.query_campaign(campaign_name, verbose=verbose, debug=debug)
+tl.list_campaigns(verbose=verbose, debug=debug)
 tl.predict_campaign(eval_filepath, campaign_name,
-                    server=server, verbose=verbose, debug=debug)
-tl.delete_campaign(campaign_name, server=server, verbose=verbose, debug=debug)
-tl.delete_dataset(dataset_name, server=server,
+                    verbose=verbose, debug=debug)
+tl.delete_campaign(campaign_name, verbose=verbose, debug=debug)
+tl.delete_dataset(dataset_name,
                   verbose=verbose, debug=debug)

--- a/scripts/train_campaign.py
+++ b/scripts/train_campaign.py
@@ -9,6 +9,4 @@ directory = os.path.join("campaigns", "biscuits")
 filename = "params.json"
 campaign_name = "biscuits"
 filepath = os.path.join(directory, filename)
-server = tl.get_command_line_args().server
-tl.train_campaign(filepath, campaign_name, server=server,
-                  verbose=True, debug=True)
+tl.train_campaign(filepath, campaign_name, verbose=True, debug=True)

--- a/scripts/upload_dataset.py
+++ b/scripts/upload_dataset.py
@@ -8,5 +8,4 @@ print()  #  Initial white space
 directory = "datasets"
 filename = "biscuits.csv"
 filepath = os.path.join(directory, filename)
-server = tl.get_command_line_args().server
-tl.upload_dataset(filepath, server=server, verbose=True, debug=True)
+tl.upload_dataset(filepath, verbose=True, debug=True)

--- a/twinlab/client.py
+++ b/twinlab/client.py
@@ -10,11 +10,12 @@ import pandas as pd
 
 # Project imports
 from . import utils
+from .settings import ENV
 
 ### Dataset functions ###
 
 
-def upload_dataset(filepath_or_df: Union[str, pd.DataFrame], dataset_name=None, server="cloud", verbose=False, debug=False) -> None:
+def upload_dataset(filepath_or_df: Union[str, pd.DataFrame], dataset_name=None, verbose=False, debug=False) -> None:
     """
     # Upload dataset
 
@@ -23,10 +24,8 @@ def upload_dataset(filepath_or_df: Union[str, pd.DataFrame], dataset_name=None, 
     **NOTE:** Your user information is automatically added to the request using the `.env` file.
 
     ## Arguments
-
     - `filepath_or_df`: `str` | `Dataframe`; location of csv dataset on local machine or `pandas` dataframe
     - `dataset_name`: `str`; name for the dataset when saved to the twinLab cloud
-    - `server`: `str`; {`"local"`, `"dev"`, `"stage"`, `"cloud"`}
     - `verbose`: `bool` determining level of information returned to the user
     - `debug`: `bool` determining level of information logged on the server
 
@@ -69,7 +68,7 @@ def upload_dataset(filepath_or_df: Union[str, pd.DataFrame], dataset_name=None, 
     # Get the upload URL
     headers = utils.construct_standard_headers(debug=debug)
     headers["X-Dataset"] = dataset_name
-    lambda_url = utils.get_server_url(server) + "/generate_upload_url"
+    lambda_url = ENV.TWINLAB_SERVER + "/generate_upload_url"
     r = requests.get(lambda_url, headers=headers)
     utils.check_response(r)
 
@@ -89,13 +88,13 @@ def upload_dataset(filepath_or_df: Union[str, pd.DataFrame], dataset_name=None, 
         print(f"Uploading {dataset_name}")
 
     # Process the uploaded dataset remotely
-    process_url = utils.get_server_url(server) + "/process_uploaded_dataset"
+    process_url = ENV.TWINLAB_SERVER + "/process_uploaded_dataset"
     r = requests.post(process_url, headers=headers)
     if verbose:
         utils.print_response_message(r)
 
 
-def query_dataset(dataset_name: str, server="cloud", verbose=False, debug=False) -> pd.DataFrame:
+def query_dataset(dataset_name: str, verbose=False, debug=False) -> pd.DataFrame:
     """
     # Query dataset
 
@@ -104,9 +103,7 @@ def query_dataset(dataset_name: str, server="cloud", verbose=False, debug=False)
     **NOTE:** Your user information is automatically added to the request using the `.env` file.
 
     ## Arguments
-
     - `dataset_name`: `str`; name of dataset on S3 (same as the uploaded file name)
-    - `server`: `str`; {`"local"`, `"dev"`, `"stage"`, `"cloud"`}
     - `verbose`: `bool` determining level of information returned to the user
     - `debug`: `bool` determining level of information logged on the server
 
@@ -124,7 +121,7 @@ def query_dataset(dataset_name: str, server="cloud", verbose=False, debug=False)
     print(df)
     ```
     """
-    url = utils.get_server_url(server) + "/query_dataset"
+    url = ENV.TWINLAB_SERVER + "/query_dataset"
     headers = utils.construct_standard_headers(debug=debug)
     headers["X-Dataset"] = dataset_name
     r = requests.get(url, headers=headers)
@@ -136,7 +133,7 @@ def query_dataset(dataset_name: str, server="cloud", verbose=False, debug=False)
     return df
 
 
-def list_datasets(server="cloud", verbose=False, debug=False) -> Union[list, None]:
+def list_datasets(verbose=False, debug=False) -> Union[list, None]:
     """
     # List datasets
 
@@ -145,8 +142,6 @@ def list_datasets(server="cloud", verbose=False, debug=False) -> Union[list, Non
     **NOTE:** Your user information is automatically added to the request using the `.env` file.
 
     ## Arguments
-
-    - `server`: `str`; {`"local"`, `"dev"`, `"stage"`, `"cloud"`}
     - `verbose`: `bool` determining level of information returned to the user
     - `debug`: `bool` determining level of information logged on the server
 
@@ -159,7 +154,7 @@ def list_datasets(server="cloud", verbose=False, debug=False) -> Union[list, Non
     print(datasets)
     ```
     """
-    url = utils.get_server_url(server) + "/list_datasets"
+    url = ENV.TWINLAB_SERVER + "/list_datasets"
     headers = utils.construct_standard_headers(debug=debug)
     r = requests.get(url, headers=headers)
     utils.check_response(r)
@@ -172,7 +167,7 @@ def list_datasets(server="cloud", verbose=False, debug=False) -> Union[list, Non
     return datasets
 
 
-def delete_dataset(dataset_name: str, server="cloud", verbose=False, debug=False) -> None:
+def delete_dataset(dataset_name: str, verbose=False, debug=False) -> None:
     """
     # Delete dataset
 
@@ -182,7 +177,6 @@ def delete_dataset(dataset_name: str, server="cloud", verbose=False, debug=False
 
     ## Arguments
     - `dataset_name`: `str`; name of dataset to delete from the cloud
-    - `server`: `str`; {`"local"`, `"dev"`, `"stage"`, `"cloud"`}
     - `verbose`: `bool` determining level of information returned to the user
     - `debug`: `bool` determining level of information logged on the server
 
@@ -195,7 +189,7 @@ def delete_dataset(dataset_name: str, server="cloud", verbose=False, debug=False
     tl.delete_dataset(dataset_name)
     ```
     """
-    url = utils.get_server_url(server) + "/delete_dataset"
+    url = ENV.TWINLAB_SERVER + "/delete_dataset"
     headers = utils.construct_standard_headers(debug=debug)
     headers["X-Dataset"] = dataset_name
     r = requests.post(url, headers=headers)
@@ -208,7 +202,7 @@ def delete_dataset(dataset_name: str, server="cloud", verbose=False, debug=False
 ### Campaign functions ###
 
 
-def train_campaign(filepath_or_params: Union[str, dict], campaign_name: str, server="cloud", verbose=False, debug=False) -> None:
+def train_campaign(filepath_or_params: Union[str, dict], campaign_name: str, verbose=False, debug=False) -> None:
     """
     # Train campaign
 
@@ -219,7 +213,6 @@ def train_campaign(filepath_or_params: Union[str, dict], campaign_name: str, ser
     ## Arguments
     - `filepath_or_params`: `str` | `dict`; filepath to local json or parameters dictionary for training
     - `campaign_name`: `str`; name for the final trained model
-    - `server`: `str`; {`"local"`, `"dev"`, `"stage"`, `"cloud"`}
     - `verbose`: `bool` determining level of information returned to the user
     - `debug`: `bool` determining level of information logged on the server
 
@@ -240,8 +233,9 @@ def train_campaign(filepath_or_params: Union[str, dict], campaign_name: str, ser
     tl.train_campaign(params, "my_campaign", verbose=True)
 ```
     """
-    url = utils.get_server_url(server)+"/train_campaign"
-    url = utils.get_train_campaign_url(url)
+    long_training_server = ENV.TWINLAB_TRAINING_SERVER
+    training_server = ENV.TWINLAB_SERVER + "/train_campaign"
+    url = long_training_server if long_training_server else training_server
     headers = utils.construct_standard_headers(debug=debug)
     headers["X-Campaign"] = campaign_name
     if isinstance(filepath_or_params, str):
@@ -257,7 +251,7 @@ def train_campaign(filepath_or_params: Union[str, dict], campaign_name: str, ser
         utils.print_response_message(r)
 
 
-def query_campaign(campaign_name: str, server="cloud", verbose=False, debug=False) -> dict:
+def query_campaign(campaign_name: str, verbose=False, debug=False) -> dict:
     """
     # Query campaign
 
@@ -266,9 +260,7 @@ def query_campaign(campaign_name: str, server="cloud", verbose=False, debug=Fals
     **NOTE:** Your user information is automatically added to the request using the `.env` file.
 
     ## Arguments
-
     - `campaign_name`: `str`; name of trained model to query
-    - `server`: `str`; {`"local"`, `"dev"`, `"stage"`, `"cloud"`}
     - `verbose`: `bool` determining level of information returned to the user
     - `debug`: `bool` determining level of information logged on the server
 
@@ -285,7 +277,7 @@ def query_campaign(campaign_name: str, server="cloud", verbose=False, debug=Fals
     tl.query_campaign(campaign)
     ```
     """
-    url = utils.get_server_url(server) + "/query_campaign"
+    url = ENV.TWINLAB_SERVER + "/query_campaign"
     headers = utils.construct_standard_headers(debug=debug)
     headers["X-Campaign"] = campaign_name
     r = requests.get(url, headers=headers)
@@ -298,7 +290,7 @@ def query_campaign(campaign_name: str, server="cloud", verbose=False, debug=Fals
     return metadata
 
 
-def list_campaigns(server="cloud", verbose=False, debug=False) -> Union[list, None]:
+def list_campaigns(verbose=False, debug=False) -> Union[list, None]:
     """
     # List datasets
 
@@ -307,8 +299,6 @@ def list_campaigns(server="cloud", verbose=False, debug=False) -> Union[list, No
     **NOTE:** Your user information is automatically added to the request using the `.env` file.
 
     ## Arguments
-
-    - `server`: `str`; {`"local"`, `"dev"`, `"stage"`, `"cloud"`}
     - `verbose`: `bool` determining level of information returned to the user
     - `debug`: `bool` determining level of information logged on the server
 
@@ -325,7 +315,7 @@ def list_campaigns(server="cloud", verbose=False, debug=False) -> Union[list, No
     print(datasets)
     ```
     """
-    url = utils.get_server_url(server) + "/list_campaigns"
+    url = ENV.TWINLAB_SERVER + "/list_campaigns"
     headers = utils.construct_standard_headers(debug=debug)
     r = requests.get(url, headers=headers)
     utils.check_response(r)
@@ -339,7 +329,7 @@ def list_campaigns(server="cloud", verbose=False, debug=False) -> Union[list, No
 
 
 def predict_campaign(
-    filepath_or_df: Union[str, pd.DataFrame], campaign_name: str, server="cloud", verbose=False, debug=False
+    filepath_or_df: Union[str, pd.DataFrame], campaign_name: str, verbose=False, debug=False
 ) -> tuple:
     """
     # Predict campaign
@@ -349,10 +339,8 @@ def predict_campaign(
     **NOTE:** Your user information is automatically added to the request using the `.env` file.
 
     ## Arguments
-
     - `filepath_or_df`: `str`; location of csv dataset on local machine for evaluation or `pandas` dataframe
     - `campaign_name`: `str`; name of pre-trained model to use for predictions
-    - `server`: `str`; {`"local"`, `"dev"`, `"stage"`, `"cloud"`}
     - `verbose`: `bool` determining level of information returned to the user
     - `debug`: `bool` determining level of information logged on the server
 
@@ -385,7 +373,7 @@ def predict_campaign(
     tl.upload_dataset(df, campaign_name)
     ```
     """
-    url = utils.get_server_url(server) + "/predict_campaign"
+    url = ENV.TWINLAB_SERVER + "/predict_campaign"
     if isinstance(filepath_or_df, pd.DataFrame):  # Data frames
         buffer = io.BytesIO()
         filepath_or_df.to_csv(buffer, index=False)
@@ -407,7 +395,7 @@ def predict_campaign(
     return df_mean, df_std
 
 
-def delete_campaign(campaign_name: str, server="cloud", verbose=False, debug=False) -> None:
+def delete_campaign(campaign_name: str, verbose=False, debug=False) -> None:
     """
     # Delete campaign
 
@@ -417,7 +405,6 @@ def delete_campaign(campaign_name: str, server="cloud", verbose=False, debug=Fal
 
     ## Arguments
     - `campaign_name`: `str`; name of trained model to delete from the cloud
-    - `server`: `str`; {`"local"`, `"dev"`, `"stage"`, `"cloud"`}
     - `verbose`: `bool` determining level of information returned to the user
     - `debug`: `bool` determining level of information logged on the server
 
@@ -430,7 +417,7 @@ def delete_campaign(campaign_name: str, server="cloud", verbose=False, debug=Fal
     tl.delete_campaign(campaign)
     ```
     """
-    url = utils.get_server_url(server) + "/delete_campaign"
+    url = ENV.TWINLAB_SERVER + "/delete_campaign"
     headers = utils.construct_standard_headers(debug=debug)
     headers["X-Campaign"] = campaign_name
     r = requests.post(url, headers=headers)

--- a/twinlab/settings.py
+++ b/twinlab/settings.py
@@ -6,10 +6,10 @@ from pydantic import BaseSettings
 
 
 class Environment(BaseSettings):
-    # TODO: Add train URL?
-    TWINLAB_LOCAL_SERVER: Optional[str]
-    TWINLAB_DEV_SERVER: Optional[str]
-    TWINLAB_STAGE_SERVER: Optional[str]
+    # TWINLAB_LOCAL_SERVER: Optional[str]
+    # TWINLAB_DEV_SERVER: Optional[str]
+    # TWINLAB_STAGE_SERVER: Optional[str]
+    TWINLAB_TRAINING_SERVER: Optional[str]
     TWINLAB_SERVER: str
     TWINLAB_GROUPNAME: str
     TWINLAB_USERNAME: str

--- a/twinlab/utils.py
+++ b/twinlab/utils.py
@@ -18,23 +18,6 @@ PARAMS_COERCION = {  # Convert these names in the params file
     "dataset": "filename",
 }
 
-# twinLab server URLs TODO: These should not be hard-coded
-TWINLAB_DEV_SERVER = "https://mt9w8ln59j.execute-api.eu-west-2.amazonaws.com/dev"
-TWINLAB_SERVER = "https://4b7lweoe60.execute-api.eu-west-2.amazonaws.com/stage"
-TWINLAB_STAGE_SERVER = "https://qisuqloa39.execute-api.eu-west-2.amazonaws.com/prod"
-
-# Train campaign server URLs TODO: Move these to .env?
-TRAIN_DEV_SERVER = "https://pdersvjxmgrkqojwyeyocqm7le0iwtkx.lambda-url.eu-west-2.on.aws/"
-TRAIN_STAGE_SERVER = "https://b7vgjlsn73e7n7kci5rwoxjc7e0pkcqn.lambda-url.eu-west-2.on.aws/"
-TRAIN_SERVER = "https://cma567qwquixu7bbjcnhbjsxjm0yumvu.lambda-url.eu-west-2.on.aws/"
-
-# Mapping
-TRAIN_URLS = {
-    TWINLAB_DEV_SERVER: TRAIN_DEV_SERVER,
-    TWINLAB_STAGE_SERVER: TRAIN_STAGE_SERVER,
-    TWINLAB_SERVER: TRAIN_SERVER,
-}
-
 
 ### Utility functions ###
 
@@ -80,42 +63,6 @@ def construct_standard_headers(debug=False) -> dict:
         "X-Debug": str(debug).lower(),
     }
     return headers
-
-
-def get_server_url(server: str) -> str:
-    """
-    The URL is the dockerised lambda function that's been set up in cloud by alexander
-    """
-    if server == "local":
-        baseURL = ENV.TWINLAB_LOCAL_SERVER
-    elif server == "dev":
-        baseURL = ENV.TWINLAB_DEV_SERVER
-    elif server == "stage":
-        baseURL = ENV.TWINLAB_STAGE_SERVER
-    elif server == "cloud":
-        baseURL = ENV.TWINLAB_SERVER
-    else:
-        print("Server:", server)
-        raise ValueError(
-            "Server must be either 'local', 'dev', 'stage', or 'cloud'")
-    if baseURL is None:  # Catch if the server URL has not been set
-        raise ValueError("Server URL not set")
-    return baseURL
-
-
-def get_train_campaign_url(server_url: str) -> str:
-    """
-    Get the URL for the train_campaign lambda function
-    These are different to avoid the AWS Lambda 29s gateway timeout
-    """
-    # if server == "dev":
-    #     url = TRAIN_CAMPAIGN_DEV_URL
-    # elif server == "stage":
-    #     url = TRAIN_CAMPAIGN_STAGE_URL
-    # elif server == "cloud":
-    #     url = TRAIN_CAMPAIGN_CLOUD_URL
-    url = TRAIN_URLS[server_url] if server_url in TRAIN_URLS else server_url
-    return url
 
 
 def coerce_params_dict(params: dict) -> dict:


### PR DESCRIPTION
Should the server information only be specified in the `.env` file, rather than appear as a parameter to be passed to the core `twinLab` routines? This pull request addresses this. Not sure if it should be merged.